### PR TITLE
#BuidlGuidl5 added check-in counter from the Batch Registry contract

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -5,7 +5,7 @@ import { MetaHeader } from "~~/components/MetaHeader";
 import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
-  const { data: ctr } = useScaffoldContractRead({
+  const { data: checkInCounter, isLoading: isCounterLoading } = useScaffoldContractRead({
     contractName: "BatchRegistry",
     functionName: "checkedInCounter",
   });
@@ -22,7 +22,7 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>{ctr ? Number(ctr) : 0}</span>
+            <span>{isCounterLoading ? "Loading..." : checkInCounter?.toString()}</span>
           </p>
         </div>
 

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -2,8 +2,14 @@ import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { MetaHeader } from "~~/components/MetaHeader";
+import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const { data: ctr } = useScaffoldContractRead({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <MetaHeader />
@@ -16,7 +22,7 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            <span>{ctr ? Number(ctr) : 0}</span>
           </p>
         </div>
 


### PR DESCRIPTION
## Description

A counter to show how many builders are checked-in is added into index.tsx file

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{8}_
Follows instruction for issue https://github.com/BuidlGuidl/batch1.buidlguidl.com/issues/8

Your ENS/address: babacan.eth / 0x5D70E3b540f58beCd10B74f6c0958b31e3190DA7

