### PR TITLE
Feat/list current members

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import AccountInfo from "./batch1/AccountInfo";
-import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
+import { Bars3Icon, BugAntIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
 
@@ -17,6 +17,11 @@ export const menuLinks: HeaderMenuLink[] = [
   {
     label: "Home",
     href: "/",
+  },
+  {
+    label: "Builders",
+    href: "/builders",
+    icon: <WrenchScrewdriverIcon className="h-4 w-4" />,
   },
   {
     label: "Debug Contracts",

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -14,6 +14,7 @@ type AddressProps = {
   disableAddressLink?: boolean;
   format?: "short" | "long";
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  hideCopyIcon?: boolean;
 };
 
 const blockieSizeMap = {
@@ -29,7 +30,7 @@ const blockieSizeMap = {
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
-export const Address = ({ address, disableAddressLink, format, size = "base" }: AddressProps) => {
+export const Address = ({ address, disableAddressLink, format, size = "base", hideCopyIcon }: AddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -103,27 +104,28 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
           {displayAddress}
         </a>
       )}
-      {addressCopied ? (
-        <CheckCircleIcon
-          className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
-          aria-hidden="true"
-        />
-      ) : (
-        <CopyToClipboard
-          text={address}
-          onCopy={() => {
-            setAddressCopied(true);
-            setTimeout(() => {
-              setAddressCopied(false);
-            }, 800);
-          }}
-        >
-          <DocumentDuplicateIcon
+      {!hideCopyIcon &&
+        (addressCopied ? (
+          <CheckCircleIcon
             className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
             aria-hidden="true"
           />
-        </CopyToClipboard>
-      )}
+        ) : (
+          <CopyToClipboard
+            text={address}
+            onCopy={() => {
+              setAddressCopied(true);
+              setTimeout(() => {
+                setAddressCopied(false);
+              }, 800);
+            }}
+          >
+            <DocumentDuplicateIcon
+              className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+              aria-hidden="true"
+            />
+          </CopyToClipboard>
+        ))}
     </div>
   );
 };

--- a/packages/nextjs/pages/builders/index.tsx
+++ b/packages/nextjs/pages/builders/index.tsx
@@ -11,7 +11,7 @@ const BuilderPage: NextPage = () => {
   } = useScaffoldEventHistory({
     contractName: "BatchRegistry",
     eventName: "CheckedIn",
-    fromBlock: 0n,
+    fromBlock: 114830037n,
   });
 
   const firstTimeCheckInEvents = eventData?.filter(({ args: { first } }) => first);

--- a/packages/nextjs/pages/builders/index.tsx
+++ b/packages/nextjs/pages/builders/index.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import type { NextPage } from "next";
+import { Address } from "~~/components/scaffold-eth";
+import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
+
+const BuilderPage: NextPage = () => {
+  const {
+    data: eventData,
+    isLoading,
+    error,
+  } = useScaffoldEventHistory({
+    contractName: "BatchRegistry",
+    eventName: "CheckedIn",
+    fromBlock: 0n,
+  });
+
+  const firstTimeCheckInEvents = eventData?.filter(({ args: { first } }) => first);
+  const builders = firstTimeCheckInEvents?.map(({ args: { builder } }) => builder);
+
+  return (
+    <div className="w-full flex justify-center items-center">
+      <div className="flex-col m-10 col-span-1 lg:col-span-2 flex flex-col gap-6">
+        {error && <h3>Had a problem fetching builder data</h3>}
+        <div className="z-10">
+          <div className="bg-base-100 rounded-3xl shadow-md shadow-secondary border border-base-300 flex flex-col mt-10 relative">
+            <div className="h-[5rem] w-[10.5rem] bg-base-300 absolute self-start rounded-[22px] -top-[38px] -left-[1px] -z-10 py-[0.65rem] shadow-lg shadow-base-300">
+              <div className="flex items-center justify-center space-x-2">
+                <p className="my-0 text-sm">Checked In Builders</p>
+              </div>
+            </div>
+            <div className="p-5 divide-y divide-base-300">
+              {isLoading
+                ? new Array(10).fill(null).map((_, idx) => (
+                    <div key={idx} className="flex gap-2 items-center mb-2">
+                      <div className="skeleton w-10 h-10 rounded-full shrink-0"></div>
+                      <div className="flex flex-col gap-4">
+                        <div className="skeleton h-4 w-28"></div>
+                      </div>
+                    </div>
+                  ))
+                : builders?.map(builderAddress => (
+                    <Link
+                      key={builderAddress}
+                      href={`/builders/${builderAddress}`}
+                      className="hover:bg-secondary hover:shadow-md focus:!bg-secondary active:!text-neutral py-1.5 px-3 text-sm rounded gap-2 grid grid-flow-col"
+                    >
+                      <Address disableAddressLink hideCopyIcon address={builderAddress} size="xl" />
+                    </Link>
+                  ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BuilderPage;


### PR DESCRIPTION
## Description

Adds a new page listing all builders and linking to their profile pages.

https://github.com/BuidlGuidl/batch1.buidlguidl.com/assets/22231097/3acf34ab-13b3-4efc-99ec-e186b34d1070

## Additional Information
- Also updates the [`<Address/>` component](https://github.com/BuidlGuidl/batch1.buidlguidl.com/blob/main/packages/nextjs/components/scaffold-eth/Address.tsx) to accept an optional `hideCopyIcon` prop

## Related Issues
#3 

Your ENS/address: `websurfer.eth`
